### PR TITLE
Linkear shared library en la compilación

### DIFF
--- a/src/compilation.mk
+++ b/src/compilation.mk
@@ -10,6 +10,9 @@ IDIRS += $(addsuffix /include,$(SHARED_LIBPATHS) $(STATIC_LIBPATHS) .)
 # Set library files' directories to (-L)ook
 LIBDIRS = $(addsuffix /bin,$(SHARED_LIBPATHS) $(STATIC_LIBPATHS))
 
+# Set shared library files to be linked using (-Wl,-rpath,) option
+SHARED_LIBDIRS = $(addsuffix /bin,$(SHARED_LIBPATHS))
+
 # Set intermediate objects
 OBJS = $(patsubst src/%.c,obj/%.o,$(SRCS_C))
 

--- a/src/execution.mk
+++ b/src/execution.mk
@@ -1,8 +1,5 @@
-LD_LIBRARY_PATH != echo $(addsuffix /bin,$(SHARED_LIBPATHS)) | tr ' ' ':'
-
 .PHONY: start
 start: all
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH); \
 	valgrind --tool=none ./$(BIN) $(ARGS)
 
 .PHONY: daemon
@@ -14,10 +11,8 @@ daemon:
 
 .PHONY: memcheck
 memcheck: all
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH); \
 	valgrind --leak-check=full $(MEMCHECK_FLAGS) ./$(BIN) $(ARGS)
 
 .PHONY: helgrind
 helgrind: all
-	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH); \
 	valgrind --tool=helgrind $(HELGRIND_FLAGS) ./$(BIN) $(ARGS)

--- a/src/project/makefile
+++ b/src/project/makefile
@@ -5,7 +5,7 @@ include settings.mk
 filename = $(1).out
 
 define compile_bin
-	gcc $(CFLAGS) -o "$@" $^ $(IDIRS:%=-I%) $(LIBDIRS:%=-L%) $(LIBS:%=-l%)
+	gcc $(CFLAGS) -o "$@" $^ $(IDIRS:%=-I%) $(LIBDIRS:%=-L%) $(SHARED_LIBDIRS:%=-Wl,-rpath,%) $(LIBS:%=-l%)
 endef
 
 define compile_objs


### PR DESCRIPTION
Ya no hace falta configurar `LD_LIBRARY_PATH` en ningún caso 🎉 